### PR TITLE
Make 'interval' generator to working as expected

### DIFF
--- a/ReactiveCheatSheet.md
+++ b/ReactiveCheatSheet.md
@@ -98,7 +98,7 @@ With these definition, and a basic definition of `integer` generator, we can map
 ```scala
 val booleans = for {x <- integers} yield x > 0
 val pairs = for {x <- integers; y<- integers} yield (x, y)
-def interval(lo: Int, hi: Int) : Generator[Int] = for { x <- integers } yield lo + x % (hi - lo)
+def interval(lo: Int, hi: Int) : Generator[Int] = for { x <- integers } yield lo + math.abs(x) % (hi - lo)
 ```
 
 


### PR DESCRIPTION
Current implementation of interval generator can generate values outside of requested scope (lo - hi)